### PR TITLE
Allow up to be called directly

### DIFF
--- a/up.go
+++ b/up.go
@@ -123,7 +123,7 @@ shell_found:
 	// if up is called directly, feed an empty ioreader else use the input piped to up
 	var stdinInit io.Reader
         if isatty.IsTerminal(os.Stdin.Fd()) {
-                stdinInit = strings.NewReader("")
+                stdinInit = bytes.NewReader([]byte(""))
         } else {
                 stdinInit = os.Stdin
         }


### PR DESCRIPTION
The following change allows for up to be called directly without first needing to pipe a command in to it.  It can still be called the normal way through a pipe.