### PR TITLE
keys: Implement unix-word-rubout (Ctrl-W)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,5 +2,6 @@ Please keep the contents of this file sorted alphabetically.
 
 Александр Крамарев <pochemuto@gmail.com>
 Calum MacRae <calum0macrae@gmail.com>
+Ghislain Rodrigues <git@ghislain-rodrigues.fr>
 Mateusz Czapliński <czapkofan@gmail.com>
 Rohan Verma <hello@rohanverma.net>

--- a/up_test.go
+++ b/up_test.go
@@ -81,3 +81,95 @@ func Test_Editor_insert(t *testing.T) {
 		}
 	}
 }
+
+func Test_Editor_unix_word_rubout(t *testing.T) {
+	tests := []struct {
+		comment       string
+		e             Editor
+		wantValue     []rune
+		wantKillspace []rune
+	}{
+		{
+			comment: "unix-word-rubout at beginning of line",
+			e: Editor{
+				value:  []rune(`abc`),
+				cursor: 0,
+			},
+			wantValue:     []rune(`abc`),
+			wantKillspace: []rune(``),
+		},
+		{
+			comment: "unix-word-rubout at soft beginning of line",
+			e: Editor{
+				value:  []rune(` abc`),
+				cursor: 1,
+			},
+			wantValue:     []rune(`abc`),
+			wantKillspace: []rune(` `),
+		},
+		{
+			comment: "unix-word-rubout until soft beginning of line",
+			e: Editor{
+				value:  []rune(` abc`),
+				cursor: 2,
+			},
+			wantValue:     []rune(` bc`),
+			wantKillspace: []rune(`a`),
+		},
+		{
+			comment: "unix-word-rubout until beginning of line",
+			e: Editor{
+				value:  []rune(`abc`),
+				cursor: 2,
+			},
+			wantValue:     []rune(`c`),
+			wantKillspace: []rune(`ab`),
+		},
+		{
+			comment: "unix-word-rubout in middle of line",
+			e: Editor{
+				value:  []rune(`lorem ipsum dolor`),
+				cursor: 11,
+			},
+			wantValue:     []rune(`lorem  dolor`),
+			wantKillspace: []rune(`ipsum`),
+		},
+		{
+			comment: "unix-word-rubout cursor at beginning of word",
+			e: Editor{
+				value:  []rune(`lorem ipsum dolor`),
+				cursor: 12,
+			},
+			wantValue:     []rune(`lorem dolor`),
+			wantKillspace: []rune(`ipsum `),
+		},
+		{
+			comment: "unix-word-rubout cursor between multiple spaces",
+			e: Editor{
+				value:  []rune(`a b   c`),
+				cursor: 5,
+			},
+			wantValue:     []rune(`a  c`),
+			wantKillspace: []rune(`b  `),
+		},
+		{
+			comment: "unix-word-rubout tab as space char (although is it a realistic case in the context of a command line instruction?)",
+			e: Editor{
+				value: []rune(`a b		c`),
+				cursor: 5,
+			},
+			wantValue: []rune(`a c`),
+			wantKillspace: []rune(`b		`),
+		},
+	}
+
+	for _, tt := range tests {
+		tt.e.unixWordRubout()
+		if string(tt.e.value) != string(tt.wantValue) {
+			t.Errorf("%q: bad value\nwant: %q\nhave: %q", tt.comment, tt.wantValue, tt.e.value)
+		}
+		if string(tt.e.killspace) != string(tt.wantKillspace) {
+			t.Errorf("%q: bad value in killspace\nwant: %q\nhave: %q", tt.comment, tt.wantKillspace, tt.e.value)
+		}
+	}
+}


### PR DESCRIPTION
unix-word-rubout erases all the characters before the cursor
until finding either a space or a BOL.

fixes #53 