### PR TITLE
readme: update link to current arch package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ by boosting any typical **Linux text-processing utils** such as `grep`, `sort`,
 ## Usage
 
 **[Download *up* for Linux](https://github.com/akavel/up/releases/latest/download/up)**
-&nbsp; | &nbsp; ArchLinux: [`pacman -S up`](https://archlinux.org/packages/community/x86_64/up/)
+&nbsp; | &nbsp; ArchLinux: [`pacman -S up`](https://archlinux.org/packages/extra/x86_64/up/)
 &nbsp; | &nbsp; FreeBSD: [`pkg install up`](https://www.freshports.org/textproc/up)
 &nbsp; | &nbsp; macOS: [`brew install up`](https://formulae.brew.sh/formula/up)
 &nbsp; | &nbsp; [Other OSes](https://github.com/akavel/up/releases)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ by boosting any typical **Linux text-processing utils** such as `grep`, `sort`,
 ## Usage
 
 **[Download *up* for Linux](https://github.com/akavel/up/releases/latest/download/up)**
-&nbsp; | &nbsp; [ArchLinux](https://wiki.archlinux.org/index.php/Arch_User_Repository): [`aur/up`](https://aur.archlinux.org/packages/up/)
+&nbsp; | &nbsp; ArchLinux: [`pacman -S up`](https://archlinux.org/packages/community/x86_64/up/)
 &nbsp; | &nbsp; FreeBSD: [`pkg install up`](https://www.freshports.org/textproc/up)
 &nbsp; | &nbsp; macOS: [`brew install up`](https://formulae.brew.sh/formula/up)
 &nbsp; | &nbsp; [Other OSes](https://github.com/akavel/up/releases)


### PR DESCRIPTION
The AUR link goes to a 404 page because `up` has been moved from the AUR to the community repo due to popularity. Fixed link in a way that is consistent with the other package links.