### PR TITLE
Adding support for printing command to stdout without saving to any file(s).

### DIFF
--- a/up.go
+++ b/up.go
@@ -290,6 +290,12 @@ func main() {
 				tui.Fini()
 				writeScript(shell, commandEditor.String(), tui)
 				return
+			case key(tcell.KeyCtrlO),
+				ctrlKey(tcell.KeyCtrlO):
+				// Write only to stdout (i.e don't persist to file)
+				tui.Fini()
+				os.Stdout.WriteString(commandEditor.String())
+				return
 			}
 		}
 	}


### PR DESCRIPTION
Without this functionality too many files get created and every time the latest file needs to be `cat`ted to see the result. Dumping the command to stdout is nifty. 
Have assigned Ctrl+O to this functionality.